### PR TITLE
Fix missing method getTestInstances in older junit version used by spring

### DIFF
--- a/src/main/java/de/retest/recheck/junit/RecheckExtension.java
+++ b/src/main/java/de/retest/recheck/junit/RecheckExtension.java
@@ -50,8 +50,23 @@ public class RecheckExtension implements BeforeTestExecutionCallback, AfterTestE
 	private void executeAll( final Consumer<RecheckLifecycle> consumer, final ExtensionContext context ) {
 		final Class<?> testClass = context.getRequiredTestClass();
 		final Consumer<Object> action = testInstance -> execute( consumer, testInstance, testClass );
-		context.getTestInstances().map( TestInstances::getAllInstances ).orElse( Collections.emptyList() )
-				.forEach( action );
+		if ( hasMethod( context, "getTestInstances" ) ) {
+			context.getTestInstances().map( TestInstances::getAllInstances ).orElse( Collections.emptyList() )
+					.forEach( action );
+		} else {
+			context.getTestInstance().ifPresent( action::accept );
+		}
+	}
+
+	/**
+	 * TODO replace with ReflectionUtilities::hasMethod after recheck release
+	 */
+	private boolean hasMethod( final Object context, final String name, final Class<?>... parameterTypes ) {
+		try {
+			return context.getClass().getMethod( name, parameterTypes ) != null;
+		} catch ( final NoSuchMethodException e ) {
+			return false;
+		}
 	}
 
 	private void execute( final Consumer<RecheckLifecycle> consumer, final Object testInstance,


### PR DESCRIPTION
Can you have a look on it? Spring uses junit 5.3.2 and if I upgrade the dependencies they break all.