### PR TITLE
Remove automatic registration of wrong junit extension class.

### DIFF
--- a/src/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,0 @@
-de.retest.junit.RecheckExtension


### PR DESCRIPTION
Junit's automatic extension registration mechanism loads the class mentioned in METAINF/services/org.junit.jupiter.api.extension.Extension. As we discussed some weeks ago, the extension should not be automatically loaded, when the jar is added to the project. Accidently, the deleted file tried to register a missing class as a junit extension. Activating junit's automatic extension registration mechanism leads to failing tests because the extension could not be registered. Therefore, the file has to be deleted.